### PR TITLE
Update athlete info styling on scoreboard

### DIFF
--- a/owlcms/frontend/components/Results.js
+++ b/owlcms/frontend/components/Results.js
@@ -59,7 +59,7 @@ class Results extends LitElement {
           </div>
 
           <table class="${this.athleteClasses()}" style="${this.athleteStyles()}">
-            ${this.athletes 
+            ${this.athletes
               ? html`
                 <tr class="head">
                   <th class="groupCol" .innerHTML="${this.t?.Start}"></th>
@@ -84,9 +84,9 @@ class Results extends LitElement {
                   <th class="sinclairRank" .innerHTML="${this.t?.Rank}"></th>
                 </tr>
                 ${(this.athletes ?? []).map(
-                    (item) => 
+                    (item) =>
                       html`
-                        ${item?.isSpacer 
+                        ${item?.isSpacer
                           ? html`
                             <tr>
                               <td class="spacer" style="grid-column: 1 / -1; justify-content: left;" innerHTML="-" ></td>
@@ -120,9 +120,9 @@ class Results extends LitElement {
                               </td>
                               <td class="vspacer"></td>
                               ${(item?.sattempts ?? []).map(
-                                (attempt, index) => 
+                                (attempt, index) =>
                                   html`
-                                    <td class="${(attempt?.liftStatus ?? "") + " " + (attempt?.className ?? "")}">   
+                                    <td class="${(attempt?.liftStatus ?? "") + " " + (attempt?.className ?? "")}">
                                       <div class="${(attempt?.liftStatus ?? "") + " " + (attempt?.className ?? "")}">${attempt?.stringValue}</div>
                                     </td>
                                   `)}
@@ -134,10 +134,10 @@ class Results extends LitElement {
                               </td>
                               <td class="vspacer"></td>
                               ${(item?.cattempts ?? []).map(
-                                (attempt, index) => 
+                                (attempt, index) =>
                                   html`
                                     <td class="${(attempt?.liftStatus ?? "") + " " + (attempt?.className ?? "")}">
-                                      <div class="${(attempt?.liftStatus ?? "") + " " + (attempt?.className ?? "")}">${attempt?.stringValue}</div> 
+                                      <div class="${(attempt?.liftStatus ?? "") + " " + (attempt?.className ?? "")}">${attempt?.stringValue}</div>
                                     </td>
                                   `)}
                               <td class="best">
@@ -177,9 +177,9 @@ class Results extends LitElement {
                     <td class="headerSpacer" innerHTML="&nbsp;" style="${"grid-column: 1 / -1; justify-content: left; " + this.leadingAthleteStyles()}"></td>
                   </tr>
                   ${(this.leaders ?? []).map(
-                    (item, index) => 
+                    (item, index) =>
                       html`
-                        ${!item?.isSpacer 
+                        ${!item?.isSpacer
                           ? html`
                               <tr class="athlete">
                                 <td class="groupCol" style="${this.leadingAthleteStyles()} "> <div>${item?.subCategory}</div></td>
@@ -196,7 +196,7 @@ class Results extends LitElement {
                                 </td>
                                 <td class="vspacer"></td>
                                 ${(item?.sattempts ?? []).map(
-                                  (attempt, index) => 
+                                  (attempt, index) =>
                                     html`
                                       <td class="${(attempt ?.liftStatus ?? "") + " " + (attempt?.className ?? "")}"><div>${attempt?.stringValue}</div></td>
                                     `)}
@@ -204,7 +204,7 @@ class Results extends LitElement {
                                 <td class="rank" style="${this.leadingAthleteStyles()} "> <div .innerHTML="${item?.snatchRank}"></div></td>
                                 <td class="vspacer" style="${this.leadingAthleteStyles()} "></td>
                                 ${(item?.cattempts ?? []).map(
-                                  (attempt, index) => 
+                                  (attempt, index) =>
                                     html`
                                       <td class="${(attempt ?.liftStatus ?? "") + " " + (attempt?.className ?? "")}"><div>${attempt?.stringValue}</div></td>
                                     `)}
@@ -232,14 +232,14 @@ class Results extends LitElement {
                     <div class="recordName recordTitle">${this.t?.records}</div>
                     <div class="recordLiftTypeSpacer"><span class="recordLiftTypeSpacer">&nbsp;</span></div>
                     ${(this.records?.recordNames ?? []).map(
-                      (n, index) => 
+                      (n, index) =>
                         html`
                           <div class="recordName">${n}</div>
                         `)}
                   </div>
 
                   ${(this.records?.recordTable ?? []).map(
-                    (c, index) => 
+                    (c, index) =>
                       html`
                         <div class="${c?.recordClass}">
                           <div class="recordCat" .innerHTML="${c?.cat}"></div>
@@ -247,7 +247,7 @@ class Results extends LitElement {
                           <div class="recordLiftType"><span class="recordLiftType">${this.t?.recordCJ}</span></div>
                           <div class="recordLiftType"><span class="recordLiftType">${this.t?.recordT}</span></div>
                           ${(c?.records ?? []).map(
-                            (r, index) => 
+                            (r, index) =>
                               html`
                                 <div class="${"recordCell " + (r?.snatchHighlight ?? "")} ">${r?.SNATCH}</div>
                                 <div class="${"recordCell " + (r?.cjHighlight ?? "")} ">${r?.CLEANJERK}</div>
@@ -282,7 +282,7 @@ class Results extends LitElement {
       groupName: {},
       groupDescription: {},
       platformName: {},
-      
+
       // during lifting
       athletes: { type: Object },
       leaders: { type: Object },
@@ -352,15 +352,15 @@ class Results extends LitElement {
   }
 
   fullNameStyles() {
-    return  "display: " + (this.mode === "WAIT" ? "none" : "flex");
+    return  "display: " + (this.mode === "WAIT" ? "none" : "block");
   }
 
   teamNameStyles() {
-    return "display: " + ((this.isBreak()) ? "none" : "flex");
+    return "display: " + (this.isBreak() ? "none" : "block");
   }
 
   attemptStyles() {
-    return "display: " + ((this.isBreak()) ? "none" : "flex");
+    return "display: " + (this.isBreak() ? "none" : "flex");
   }
 
   startNumberStyles() {
@@ -394,9 +394,9 @@ class Results extends LitElement {
   }
 
   athleteClasses() {
-    var classes = "results " 
+    var classes = "results "
     + (this.showTotal ? " total" : " nototal")
-    + (this.showLiftRanks ? " ranks" : " noranks") 
+    + (this.showLiftRanks ? " ranks" : " noranks")
     + (this.showBest ? " best" : " nobest")
     + (this.showTotalRank ? " totalRank" : " nototalRank")
     + (this.showSinclair ? " sinclair" : " nosinclair")
@@ -408,11 +408,11 @@ class Results extends LitElement {
 
   athleteStyles() {
     return (this.mode === "WAIT" ? "display: none" : "display:grid ")
-      + (this.resultLines ? ("; --top: " + this.resultLines) : "") 
+      + (this.resultLines ? ("; --top: " + this.resultLines) : "")
       + (this.leaderLines ? "; --bottom: " + this.leaderLines : "")
-      + (this.leadersLineHeight ? "; " + this.leadersLineHeight : "") 
-      + (this.leaderFillerHeight ? "; " + this.leaderFillerHeight : "") 
-      + (this.twOverride ? "; " + this.twOverride : "") 
+      + (this.leadersLineHeight ? "; " + this.leadersLineHeight : "")
+      + (this.leaderFillerHeight ? "; " + this.leaderFillerHeight : "")
+      + (this.twOverride ? "; " + this.twOverride : "")
   }
 
   leadersStyles() {
@@ -428,8 +428,8 @@ class Results extends LitElement {
   }
 
   recordsStyles() {
-    return (!this.showRecords || this.mode !== "CURRENT_ATHLETE") 
-      ? "display:none" 
+    return (!this.showRecords || this.mode !== "CURRENT_ATHLETE")
+      ? "display:none"
       : "font-size: var(--recordsFontRatio); display: block" ;
   }
 

--- a/shared/src/main/resources/css/grid/results.css
+++ b/shared/src/main/resources/css/grid/results.css
@@ -560,6 +560,7 @@ td {
 
 .attemptBar .athleteInfo {
     display: flex;
+    gap: 0.5rem;
     font-size: var(--athleteNameFontSize);
     justify-content: space-between;
     align-items: baseline;
@@ -581,6 +582,7 @@ td {
 
 .athleteInfo .attempt {
     color: var(--athleteAttemptColor);
+    white-space: nowrap;
 }
 
 .athleteInfo .weight {
@@ -588,6 +590,7 @@ td {
     display: flex;
     justify-content: center;
     align-items: baseline;
+    white-space: nowrap;
 }
 
 .athleteInfo .timer {

--- a/shared/src/main/resources/css/nogrid/results.css
+++ b/shared/src/main/resources/css/nogrid/results.css
@@ -150,7 +150,7 @@ table.results.sinclair.nosinclairRank {
 }
 
 /* default cell colors, backgrounds and borders */
-:host table.results tr td, 
+:host table.results tr td,
 :host table.results tr th {
     align-items: center;
     background-color: var(--BackgroundColor);
@@ -162,7 +162,7 @@ table.results.sinclair.nosinclairRank {
     font-weight: bold;
 }
 
-:host .dark table.results tr td, 
+:host .dark table.results tr td,
 :host .dark table.results tr th {
     margin-bottom: var(--rowSmallSpacerHeight);
 }
@@ -537,6 +537,7 @@ td {
 
 .attemptBar .athleteInfo {
     display: flex;
+    gap: 0.5rem;
     font-size: var(--athleteNameFontSize);
     justify-content: space-between;
     align-items: baseline;
@@ -558,6 +559,7 @@ td {
 
 .athleteInfo .attempt {
     color: var(--athleteAttemptColor);
+    white-space: nowrap;
 }
 
 .athleteInfo .weight {
@@ -565,6 +567,7 @@ td {
     display: flex;
     justify-content: center;
     align-items: baseline;
+    white-space: nowrap;
 }
 
 .athleteInfo .timer {

--- a/shared/src/main/resources/css/transparent/results.css
+++ b/shared/src/main/resources/css/transparent/results.css
@@ -173,7 +173,7 @@ table.results.sinclair.nosinclairRank {
 }
 
 /* default cell colors, backgrounds and borders */
-:host table.results tr td, 
+:host table.results tr td,
 :host table.results tr th {
     align-items: center;
     background-color: var(--BackgroundColor);
@@ -185,7 +185,7 @@ table.results.sinclair.nosinclairRank {
     font-weight: bold;
 }
 
-:host .dark table.results tr td, 
+:host .dark table.results tr td,
 :host .dark table.results tr th {
     margin-bottom: var(--rowSmallSpacerHeight);
 }
@@ -561,6 +561,7 @@ td {
 
 .attemptBar .athleteInfo {
     display: flex;
+    gap: 0.5rem;
     font-size: var(--athleteNameFontSize);
     justify-content: space-between;
     align-items: baseline;
@@ -582,6 +583,7 @@ td {
 
 .athleteInfo .attempt {
     color: var(--athleteAttemptColor);
+    white-space: nowrap;
 }
 
 .athleteInfo .weight {
@@ -589,6 +591,7 @@ td {
     display: flex;
     justify-content: center;
     align-items: baseline;
+    white-space: nowrap;
 }
 
 .athleteInfo .timer {

--- a/shared/src/test/resources/styles/3-letter-teams/results.css
+++ b/shared/src/test/resources/styles/3-letter-teams/results.css
@@ -19,9 +19,9 @@
     --birthWidth: 6ch;
     --liftResultWidth: 8ch;
 
-    /* to show these columns 
+    /* to show these columns
     - change hidden to visible
-    - set the width to value like 8ch 
+    - set the width to value like 8ch
     */
     --custom1Width: 0;
     --custom1Visibility: hidden;
@@ -110,7 +110,7 @@ table.results.sinclair {
 }
 
 /* default cell colors, backgrounds and borders */
-:host .dark table.results tr td, 
+:host .dark table.results tr td,
 :host .dark table.results tr th {
     background-color: var(--darkBackgroundColor);
     color: var(--darkTextColor);
@@ -622,6 +622,7 @@ td {
 
 .attemptBar .athleteInfo {
     display: flex;
+    gap: 0.5rem;
     font-size: 3.4vh;
     justify-content: space-between;
     align-items: baseline;
@@ -643,6 +644,7 @@ td {
 
 .athleteInfo .attempt {
     color: var(--athleteAttemptColor);
+    white-space: nowrap;
 }
 
 .athleteInfo .weight {
@@ -650,6 +652,7 @@ td {
     display: flex;
     justify-content: center;
     align-items: baseline;
+    white-space: nowrap;
 }
 
 .athleteInfo .timer {

--- a/shared/src/test/resources/styles/TV/results.css
+++ b/shared/src/test/resources/styles/TV/results.css
@@ -19,9 +19,9 @@
     --birthWidth: 6ch;
     --liftResultWidth: 8ch;
 
-    /* to show these columns 
+    /* to show these columns
     - change hidden to visible
-    - set the width to value like 8ch 
+    - set the width to value like 8ch
     */
     --custom1Width: 0;
     --custom1Visibility: hidden;
@@ -110,7 +110,7 @@ table.results.sinclair {
 }
 
 /* default cell colors, backgrounds and borders */
-:host .dark table.results tr td, 
+:host .dark table.results tr td,
 :host .dark table.results tr th {
     background-color: var(--darkBackgroundColor);
     color: var(--darkTextColor);
@@ -622,6 +622,7 @@ td {
 
 .attemptBar .athleteInfo {
     display: flex;
+    gap: 0.5rem;
     font-size: 3.4vh;
     justify-content: space-between;
     align-items: baseline;
@@ -646,6 +647,7 @@ td {
 
 .athleteInfo .attempt {
     color: var(--athleteAttemptColor);
+    white-space: nowrap;
 }
 
 .athleteInfo .weight {
@@ -653,6 +655,7 @@ td {
     display: flex;
     justify-content: center;
     align-items: baseline;
+    white-space: nowrap;
 }
 
 .athleteInfo .timer {

--- a/shared/src/test/resources/styles/samples/results.css
+++ b/shared/src/test/resources/styles/samples/results.css
@@ -59,7 +59,7 @@ table.results {
 }
 
 table.results.noranks {
-    --rankWidth: 0; 
+    --rankWidth: 0;
     --rankVisibility: hidden;
 }
 
@@ -311,17 +311,17 @@ table {
     flex: 1;
     display: grid;
     border-collapse: collapse;
-    grid-template-rows: 
-        repeat(var(--top), min-content) 
+    grid-template-rows:
+        repeat(var(--top), min-content)
         1fr
         repeat(var(--bottom), min-content);
     grid-template-columns:
-        var(--startWidth) 
-        minmax(50px, 1fr) 
+        var(--startWidth)
+        minmax(50px, 1fr)
         var(--categoryWidth)
         var(--birthWidth)
         minmax(50px, var(--teamColumnRatio))
-        repeat(3, var(--liftResultWidth)) 
+        repeat(3, var(--liftResultWidth))
         repeat(var(--nbRanks), var(--rankWidth))
         repeat(3, var(--liftResultWidth))
         repeat(var(--nbRanks), var(--rankWidth))
@@ -336,12 +336,12 @@ table.medals {
     display: grid;
     border-collapse: collapse;
     grid-template-columns:
-        var(--startWidth) 
-        minmax(50px, 1fr) 
+        var(--startWidth)
+        minmax(50px, 1fr)
         var(--categoryWidth)
         var(--birthWidth)
         minmax(50px, var(--teamColumnRatio))
-        repeat(3, var(--liftResultWidth)) 
+        repeat(3, var(--liftResultWidth))
         repeat(var(--nbRanks), var(--rankWidth))
         repeat(3, var(--liftResultWidth))
         repeat(var(--nbRanks), var(--rankWidth))
@@ -462,6 +462,7 @@ td {
 
 .attemptBar .athleteInfo {
     display: flex;
+    gap: 0.5rem;
     font-size: 3.4vh;
     justify-content: space-between;
     align-items: baseline;
@@ -488,6 +489,7 @@ td {
     align-self: center;
     font-size: 3vh;
     color: var(--athleteAttemptColor);
+    white-space: nowrap;
 }
 
 .athleteInfo .weight {
@@ -495,10 +497,10 @@ td {
     font-size: 4vh;
     color: var(--athleteAttemptWeightColor);
     display: flex;
-    justify-content:
-    center;
+    justify-content: center;
     align-items: baseline;
     font-weight: bold;
+    white-space: nowrap;
 }
 
 .athleteInfo .timer {


### PR DESCRIPTION
On narrow screens, the attempt number and weight can wrap to two lines. Since these have fully controlled content and we know they'll never get large, we can force them to always fully display on one line.

The athlete name and club name have properties to apply ellipsis on overflow, but because they're forced to `display: flex`, the properties don't apply. Instead, we set them to `display: block`.

I also added a gap on the parent element to ensure there's some minimum spacing between elements in the case of overflow.

## Before

when everything fits:
![Screenshot 2024-05-07 at 7 45 32 AM](https://github.com/jflamy/owlcms4/assets/141167/502212cf-0a6a-4393-a8ef-bdb0d6671074)

when names overflow:
![Screenshot 2024-05-07 at 7 46 01 AM](https://github.com/jflamy/owlcms4/assets/141167/f660c7b0-730e-4a64-9620-6c6b1966f054)

## After

when everything fits:
![Screenshot 2024-05-07 at 7 38 08 AM](https://github.com/jflamy/owlcms4/assets/141167/f080bc31-2926-4b0a-bd24-9320bc93f5b4)

when names overflow:
![Screenshot 2024-05-07 at 7 37 53 AM](https://github.com/jflamy/owlcms4/assets/141167/4e7e7342-49aa-4875-94d0-ccaa9bef7252)