### PR TITLE
do not use age groups for start numbers; closes #1025

### DIFF
--- a/owlcms/src/main/java/app/owlcms/data/athleteSort/RegistrationOrderComparator.java
+++ b/owlcms/src/main/java/app/owlcms/data/athleteSort/RegistrationOrderComparator.java
@@ -50,13 +50,6 @@ public class RegistrationOrderComparator extends AbstractLifterComparator implem
 			return compare;
 		}
 
-		compare = AgeGroup.registrationComparator.compare(category1.getAgeGroup(), category2.getAgeGroup());
-		if (compare != 0) {
-			// logger.debug("agegroup {} {} {} ", category1.getAgeGroup(), compare > 0 ? ">" : "<",
-			// category2.getAgeGroup());
-			return compare;
-		}
-
 		// same division, same gender, rank according to maximumWeight.
 		Double value1 = category1.getMaximumWeight();
 		Double value2 = category2.getMaximumWeight();
@@ -67,7 +60,8 @@ public class RegistrationOrderComparator extends AbstractLifterComparator implem
 		}
 		
 		if (!Competition.getCurrent().isDisplayByAgeGroup() && Config.getCurrent().featureSwitch("bwClassThenAgeGroup")) {
-			// for readability reason, we group by age group within the bodyweight category.
+			// for scoreboard readability, we group by age group within the bodyweight category.
+			// (used in South America)
 			compare = AgeGroup.registrationComparator.compare(category1.getAgeGroup(), category2.getAgeGroup());
 			if (compare != 0) {
 				traceComparison("categoryRegistrationComparator agegroup", category1, category1.getAgeGroup(), category2, category2.getAgeGroup(), compare);		
@@ -79,7 +73,7 @@ public class RegistrationOrderComparator extends AbstractLifterComparator implem
 	
 	public static Comparator<Athlete> athleteRegistrationOrderComparator = (lifter1, lifter2) -> {
 		int compare;
-		if (!Competition.getCurrent().isDisplayByAgeGroup()) {
+		if (Competition.getCurrent().isDisplayByAgeGroup() || Competition.getCurrent().isMasters()) {
 			compare = ageGroupRegistrationComparator.compare(lifter1.getAgeGroup(), lifter2.getAgeGroup());
 			if (compare != 0) {
 				traceComparison("RegistrationOrderComparator ageGroup", lifter1, lifter1.getAgeGroup(), lifter2,

--- a/owlcms/src/main/java/app/owlcms/data/group/Group.java
+++ b/owlcms/src/main/java/app/owlcms/data/group/Group.java
@@ -68,6 +68,7 @@ public class Group implements Comparable<Group> {
 	private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm";
 	private final static DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder().parseLenient()
 	        .appendPattern(DATE_FORMAT).toFormatter();
+	
 	public static Comparator<Athlete> weighinTimeComparator = (lifter1, lifter2) -> {
 		Group lifter1Group = lifter1.getGroup();
 		Group lifter2Group = lifter2.getGroup();

--- a/owlcms/src/main/java/app/owlcms/nui/lifting/WeighinContent.java
+++ b/owlcms/src/main/java/app/owlcms/nui/lifting/WeighinContent.java
@@ -31,7 +31,10 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.GridSortOrder;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -41,6 +44,7 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.data.renderer.NumberRenderer;
 import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -672,6 +676,8 @@ public class WeighinContent extends BaseContent
 		grid.addColumn("gender").setHeader(Translator.translate("Gender")).setAutoWidth(true);
 		grid.addColumn(new TextRenderer<>(a -> a.getAgeGroupDisplayName())).setHeader(Translator.translate("AgeGroup"))
 		        .setAutoWidth(true);
+		Column<Athlete> groupCol = grid.addColumn("group").setHeader(Translator.translate("Group")).setAutoWidth(true)
+		        .setTextAlign(ColumnTextAlign.CENTER);
 		grid.addColumn("category").setHeader(Translator.translate("Category")).setAutoWidth(true);
 		grid.addColumn(new NumberRenderer<>(Athlete::getBodyWeight, "%.2f", this.getLocale()))
 		        .setSortProperty("bodyWeight")
@@ -682,6 +688,13 @@ public class WeighinContent extends BaseContent
 		grid.addColumn("entryTotal").setHeader(Translator.translate("EntryTotal")).setAutoWidth(true);
 		grid.addColumn("federationCodes").setHeader(Translator.translate("Registration.FederationCodesShort"))
 		        .setAutoWidth(true);
+		
+		List<GridSortOrder<Athlete>> sortOrder = new ArrayList<>();
+		// groupWeighinTimeComparator implements traditional platform name comparisons e.g. USAW.
+		groupCol.setComparator((a,b) -> Group.groupWeighinTimeComparator.compare(a.getGroup(), b.getGroup()));
+		sortOrder.add(new GridSortOrder<Athlete>(groupCol, SortDirection.ASCENDING));
+		grid.sort(sortOrder);
+		
 		NextCrudGrid crudGrid = new NextCrudGrid(Athlete.class, new OwlcmsGridLayout(Athlete.class) {
 			@Override
 			public void hideForm() {

--- a/owlcms/src/main/java/app/owlcms/nui/preparation/RegistrationContent.java
+++ b/owlcms/src/main/java/app/owlcms/nui/preparation/RegistrationContent.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.GridSortOrder;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -40,6 +42,7 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.data.renderer.NumberRenderer;
 import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -574,7 +577,7 @@ public class RegistrationContent extends BaseContent implements CrudListener<Ath
 		grid.addColumn(new NumberRenderer<>(Athlete::getBodyWeight, "%.2f", this.getLocale()))
 		        .setSortProperty("bodyWeight")
 		        .setHeader(Translator.translate("BodyWeight")).setAutoWidth(true).setTextAlign(ColumnTextAlign.CENTER);
-		grid.addColumn("group").setHeader(Translator.translate("Group")).setAutoWidth(true)
+		Column<Athlete> groupCol = grid.addColumn("group").setHeader(Translator.translate("Group")).setAutoWidth(true)
 		        .setTextAlign(ColumnTextAlign.CENTER);
 		grid.addColumn("eligibleCategories").setHeader(Translator.translate("Registration.EligibleCategories"))
 		        .setAutoWidth(true);
@@ -584,6 +587,12 @@ public class RegistrationContent extends BaseContent implements CrudListener<Ath
 		        .setTextAlign(ColumnTextAlign.CENTER);
 		grid.addColumn("federationCodes").setHeader(Translator.translate("Registration.FederationCodesShort"))
 		        .setAutoWidth(true);
+		
+		List<GridSortOrder<Athlete>> sortOrder = new ArrayList<>();
+		// groupWeighinTimeComparator implements traditional platform name comparisons e.g. USAW.
+		groupCol.setComparator((a,b) -> Group.groupWeighinTimeComparator.compare(a.getGroup(), b.getGroup()));
+		sortOrder.add(new GridSortOrder<Athlete>(groupCol, SortDirection.ASCENDING));
+		grid.sort(sortOrder);
 
 		OwlcmsCrudGrid<Athlete> crudGrid = new OwlcmsCrudGrid<>(Athlete.class, new OwlcmsGridLayout(Athlete.class) {
 


### PR DESCRIPTION
fixes reversed test for agegroup checkbox
sets default display order for registration, documents, weigh-in to be by session