### PR TITLE
moved part of board init to onAttach after url parsing

### DIFF
--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/AbstractResultsDisplayPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/AbstractResultsDisplayPage.java
@@ -34,7 +34,7 @@ public abstract class AbstractResultsDisplayPage extends AbstractDisplayPage
 	private long lastShortcut;
 
 	public AbstractResultsDisplayPage() {
-		// intentionally empty; superclass will invoke init() as required.
+		// intentionally empty; init() will be invoked as required.
 	}
 
 	/**

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/CurrentAthletePage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/CurrentAthletePage.java
@@ -7,6 +7,7 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.QueryParameters;
@@ -49,11 +50,10 @@ public class CurrentAthletePage extends AbstractResultsDisplayPage {
 
 	@Override
 	protected void init() {
+		logger = (Logger) LoggerFactory.getLogger(CurrentAthletePage.class);
+		uiEventLogger = (Logger) LoggerFactory.getLogger("UI" + this.logger.getName());
 		var board = new CurrentAthlete(this);
 		this.setBoard(board);
-		board.setLeadersDisplay(true);
-		board.setRecordsDisplay(true);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -76,6 +76,16 @@ public class CurrentAthletePage extends AbstractResultsDisplayPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(true);
+		board.setRecordsDisplay(true);
+
+		this.addComponentAsFirst((Component) board);
 	}
 
 }

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/JuryScoreboardPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/JuryScoreboardPage.java
@@ -7,6 +7,8 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 
@@ -42,7 +44,6 @@ public class JuryScoreboardPage extends WarmupNoLeadersPage {
 		// otherwise we end up with multiple instances of the Results board.
 		var board = new ResultsJury(this);
 		this.setBoard(board);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -65,6 +66,16 @@ public class JuryScoreboardPage extends WarmupNoLeadersPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(false);
+		board.setRecordsDisplay(false);
+
+		this.addComponent((Component) board);
 	}
 
 }

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicMultiRanksPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicMultiRanksPage.java
@@ -6,6 +6,8 @@ import java.util.TreeMap;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.Subscribe;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
@@ -78,9 +80,7 @@ public class PublicMultiRanksPage extends AbstractResultsDisplayPage {
 		this.setBoard(board);
 		this.setResultsBoard(board);
 		this.setMedalsBoard(medalsBoard);
-		this.addComponent(board);
-		this.addComponent(medalsBoard);
-		medalsBoard.setVisible(false);
+
 		this.ui = UI.getCurrent();
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
@@ -104,6 +104,20 @@ public class PublicMultiRanksPage extends AbstractResultsDisplayPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(getFop());
+		medalsBoard.setFop(getFop());
+		
+		this.setResultsBoard((ResultsMultiRanks) board);
+		this.setMedalsBoard(medalsBoard);
+		
+		this.addComponent((Component) board);
+		medalsBoard.setVisible(false);
+		this.addComponent(medalsBoard);
 	}
 
 	private final ResultsMedals getMedalsBoard() {

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicNoLeadersPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicNoLeadersPage.java
@@ -8,6 +8,8 @@ import java.util.TreeMap;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.Subscribe;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
@@ -84,12 +86,8 @@ public class PublicNoLeadersPage extends AbstractResultsDisplayPage {
 	protected void createComponents() {
 		var board = new Results();
 		var medalsBoard = new ResultsMedals();
-
 		this.setBoard(board);
 		this.setResultsBoard(board);
-		this.setMedalsBoard(medalsBoard);
-		this.addComponent(board);
-		this.addComponent(medalsBoard);
 
 		medalsBoard.setDownSilenced(true);
 		medalsBoard.setDarkMode(board.isDarkMode());
@@ -103,6 +101,21 @@ public class PublicNoLeadersPage extends AbstractResultsDisplayPage {
 
 		medalsBoard.getStyle().set("display", "none");
 		this.ui = UI.getCurrent();
+	}
+	
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(getFop());
+		medalsBoard.setFop(getFop());
+		
+		this.setResultsBoard((Results) board);
+		this.setMedalsBoard(medalsBoard);
+		
+		this.addComponent((Component) board);
+		medalsBoard.setVisible(false);
+		this.addComponent(medalsBoard);
 	}
 
 	@Override

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicRankingOrderPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicRankingOrderPage.java
@@ -8,6 +8,8 @@ import java.util.TreeMap;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.Subscribe;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
@@ -86,12 +88,7 @@ public class PublicRankingOrderPage extends AbstractResultsDisplayPage {
 	protected void createComponents() {
 		var board = new ResultsRankingOrder();
 		var medalsBoard = new ResultsMedals();
-
 		this.setBoard(board);
-		this.setResultsBoard(board);
-		this.setMedalsBoard(medalsBoard);
-		this.addComponent(board);
-		this.addComponent(medalsBoard);
 
 		medalsBoard.setDownSilenced(true);
 		medalsBoard.setDarkMode(board.isDarkMode());
@@ -105,6 +102,20 @@ public class PublicRankingOrderPage extends AbstractResultsDisplayPage {
 
 		medalsBoard.getStyle().set("display", "none");
 		this.ui = UI.getCurrent();
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(getFop());
+		medalsBoard.setFop(getFop());
+		
+		this.setResultsBoard((Results) board);
+		this.setMedalsBoard(medalsBoard);
+		
+		this.addComponent((Component) board);
+		medalsBoard.setVisible(false);
+		this.addComponent(medalsBoard);
 	}
 
 	@Override

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicScoreboardPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/PublicScoreboardPage.java
@@ -8,6 +8,8 @@ import java.util.TreeMap;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.Subscribe;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
@@ -83,12 +85,7 @@ public class PublicScoreboardPage extends AbstractResultsDisplayPage {
 	protected void createComponents() {
 		var board = new Results();
 		var medalsBoard = new ResultsMedals();
-
 		this.setBoard(board);
-		this.setResultsBoard(board);
-		this.setMedalsBoard(medalsBoard);
-		this.addComponent(board);
-		this.addComponent(medalsBoard);
 
 		medalsBoard.setDownSilenced(true);
 		medalsBoard.setDarkMode(board.isDarkMode());
@@ -102,6 +99,20 @@ public class PublicScoreboardPage extends AbstractResultsDisplayPage {
 
 		medalsBoard.getStyle().set("display", "none");
 		this.ui = UI.getCurrent();
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(getFop());
+		medalsBoard.setFop(getFop());
+		
+		this.setResultsBoard((Results) board);
+		this.setMedalsBoard(medalsBoard);
+		
+		this.addComponent((Component) board);
+		medalsBoard.setVisible(false);
+		this.addComponent(medalsBoard);
 	}
 
 	@Override

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupLiftingOrderPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupLiftingOrderPage.java
@@ -5,6 +5,8 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 
@@ -36,9 +38,6 @@ public class WarmupLiftingOrderPage extends AbstractResultsDisplayPage {
 	protected void init() {
 		var board = new ResultsLiftingOrder(this);
 		this.setBoard(board);
-		board.setLeadersDisplay(true);
-		board.setRecordsDisplay(true);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -61,6 +60,16 @@ public class WarmupLiftingOrderPage extends AbstractResultsDisplayPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(true);
+		board.setRecordsDisplay(true);
+
+		this.addComponent((Component) board);
 	}
 
 }

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupMultiRanksPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupMultiRanksPage.java
@@ -5,6 +5,8 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 
@@ -32,9 +34,6 @@ public class WarmupMultiRanksPage extends AbstractResultsDisplayPage {
 	protected void init() {
 		var board = new ResultsMultiRanks();
 		this.setBoard(board);
-		board.setLeadersDisplay(true);
-		board.setRecordsDisplay(true);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -58,5 +57,14 @@ public class WarmupMultiRanksPage extends AbstractResultsDisplayPage {
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
 	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(true);
+		board.setRecordsDisplay(true);
 
+		this.addComponent((Component) board);
+	}
 }

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupNoLeadersPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupNoLeadersPage.java
@@ -5,6 +5,8 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 
@@ -34,10 +36,9 @@ public class WarmupNoLeadersPage extends WarmupScoreboardPage {
 
 	@Override
 	protected void init() {
-		// only difference is the default values
+		logger = (Logger) LoggerFactory.getLogger(WarmupNoLeadersPage.class);
 		var board = new Results();
 		this.setBoard(board);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -60,5 +61,15 @@ public class WarmupNoLeadersPage extends WarmupScoreboardPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(false);
+		board.setRecordsDisplay(false);
+
+		this.addComponent((Component) board);
 	}
 }

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupRankingOrderPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupRankingOrderPage.java
@@ -5,6 +5,8 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 
@@ -36,7 +38,6 @@ public class WarmupRankingOrderPage extends AbstractResultsDisplayPage {
 	protected void init() {
 		var board = new ResultsRankingOrder();
 		this.setBoard(board);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -59,6 +60,16 @@ public class WarmupRankingOrderPage extends AbstractResultsDisplayPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(true);
+		board.setRecordsDisplay(true);
+
+		this.addComponent((Component) board);
 	}
 
 }

--- a/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupScoreboardPage.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/scoreboards/WarmupScoreboardPage.java
@@ -7,6 +7,8 @@ import java.util.TreeMap;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 
@@ -28,7 +30,7 @@ public class WarmupScoreboardPage extends AbstractResultsDisplayPage {
 	Map<String, List<String>> urlParameterMap = new HashMap<>();
 
 	public WarmupScoreboardPage() {
-		// intentionally empty. superclass will call init() as required.
+		// intentionally empty.  init() will be called as required.
 	}
 
 	@Override
@@ -38,11 +40,13 @@ public class WarmupScoreboardPage extends AbstractResultsDisplayPage {
 
 	@Override
 	protected void init() {
-		// each superclass must this routine.
+		logger = (Logger) LoggerFactory.getLogger(WarmupScoreboardPage.class);
+		uiEventLogger = (Logger) LoggerFactory.getLogger("UI" + this.logger.getName());
+		
+		// each subclass must define this routine.
 		// otherwise we end up with multiple instances of the Results board.
 		var board = new Results();
 		this.setBoard(board);
-		this.addComponent(board);
 
 		// when navigating to the page, Vaadin will call setParameter+readParameters
 		// these parameters will be applied.
@@ -67,6 +71,16 @@ public class WarmupScoreboardPage extends AbstractResultsDisplayPage {
 		fullMap.putAll(initialMap);
 		fullMap.putAll(additionalMap);
 		setDefaultParameters(QueryParameters.simple(fullMap));
+	}
+	
+	@Override
+	protected void onAttach(AttachEvent attachEvent) {
+		DisplayParameters board = (DisplayParameters) this.getBoard();
+		board.setFop(this.getFop());
+		board.setLeadersDisplay(true);
+		board.setRecordsDisplay(true);
+
+		this.addComponent((Component) board);
 	}
 
 }


### PR DESCRIPTION
Previously FOP was in the session and in the URL.
Should no longer assume it is in the Session except for some legacy cases (like navigation from the top-level pages).
This moves the final initialization of the pages to *after* the URL have been read.
The Page object is created, it's init() is called.  Then the URL parsing takes place to navigate to the initial page rendering.  When that is done, onAttach() is called to finish the job.