### PR TITLE
Age Group: Proper validation for code length

### DIFF
--- a/owlcms/src/main/java/app/owlcms/nui/preparation/AgeGroupEditingFormFactory.java
+++ b/owlcms/src/main/java/app/owlcms/nui/preparation/AgeGroupEditingFormFactory.java
@@ -106,9 +106,10 @@ public class AgeGroupEditingFormFactory
 		formLayout.addFormItem(codeField, Translator.translate("AgeGroupCode"));
 		int maxLength = 5;
 		codeField.setRequired(true);
+		codeField.setMaxLength(maxLength);
 		this.binder.forField(codeField)
 		        .withValidator(
-		                new StringLengthValidator(Translator.translate("ThisFieldIsRequired", maxLength), 1, maxLength))
+		                new StringLengthValidator(Translator.translate("ThisFieldIsRequired", maxLength), 1, null))
 		        .withValidator(
 		                new StringLengthValidator(Translator.translate("CodeMustBeShort", maxLength), 0, maxLength))
 		        .bind(AgeGroup::getCode, AgeGroup::setCode);


### PR DESCRIPTION
Having the max length as part of the required field validation check meant that the required field error message would be displayed if the value was too long, preventing the short code error message from ever being displayed.