### PR TITLE
Update README links to point to jflamy.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Yet it is simple enough to setup that you can use it to run a club or regional c
 
 ### Features, Downloads and Installation
 
-- [Installation instructions for laptops](https://owlcms.github.io/owlcms4/#/LocalDownloads) A control panel program is used to install, update and run the system.
-- [Cloud Installation Instructions](https://owlcms.github.io/owlcms4/#/Fly) A web site is used to install the program on your own cloud instance.
-- Please refer to the [Documentation](https://owlcms.github.io/owlcms4/#)
+- [Installation instructions for laptops](https://jflamy.github.io/owlcms4/#/LocalDownloads) A control panel program is used to install, update and run the system.
+- [Cloud Installation Instructions](https://jflamy.github.io/owlcms4/#/Fly) A web site is used to install the program on your own cloud instance.
+- Please refer to the [Documentation](https://jflamy.github.io/owlcms4/#)
 
 
 ### Help, Issues, Feature Requests
@@ -20,7 +20,7 @@ Yet it is simple enough to setup that you can use it to run a club or regional c
 - [Work in Progress and Priorities](https://github.com/users/jflamy/projects/2/views/7) Shows what we are working on and what is currently planned.
 
 ### Releases
-The installation process uses either the [control panel](https://owlcms.github.io/owlcms4/#/LocalDownloads) for local deployment, or the [cloud setup site](https://owlcms.github.io/owlcms4/#/Fly).
+The installation process uses either the [control panel](https://jflamy.github.io/owlcms4/#/LocalDownloads) for local deployment, or the [cloud setup site](https://jflamy.github.io/owlcms4/#/Fly).
 The following repositories contain the files used by these mechanisms (and the release notes).
 - Stable releases are kept at https://github.com/owlcms/owlcms4/releases.
 - Preliminary releases for testing and translation are located at https://github.com/owlcms/owlcms4-prerelease/releases.


### PR DESCRIPTION
I was looking into the project to use it for a regional competition and encountered a "404 Not Found" error. I simply replaced "owlcms.github.io" with "jflamy.github.io". Greetings from Argentina.